### PR TITLE
fix[main.py]: Force path to POSIX format so Windows

### DIFF
--- a/src/edit_python_pe/main.py
+++ b/src/edit_python_pe/main.py
@@ -5,7 +5,7 @@ import os
 import re
 from datetime import datetime
 from time import sleep
-
+import pathlib
 import pygit2
 from github import Github
 from github.GithubException import BadCredentialsException, GithubException
@@ -522,6 +522,7 @@ class MemberApp(App):
         # commit & push
         repo = pygit2.Repository(self.REPO_PATH)
         rel_path = os.path.relpath(file_path, self.REPO_PATH)
+        rel_path = pathlib.Path(rel_path).as_posix() # Force path to POSIX format so Windows backslashes (\) don't break pygit2
         repo.index.add(rel_path)
         repo.index.write()
         author_sig = pygit2.Signature(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue on Windows where backslashes in file paths could cause failures when saving or committing changes, ensuring paths are handled consistently.
  * Improved cross-platform reliability by normalizing paths to a POSIX format before indexing with the Git backend, preventing unexpected errors during version control operations.
  * Users should now experience smoother save/commit workflows on Windows environments without manual path adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->