### PR TITLE
feat: add sensitive data tooltips to all form fields

### DIFF
--- a/src/edit_python_pe/main.py
+++ b/src/edit_python_pe/main.py
@@ -69,17 +69,16 @@ class MemberApp(App):
         # 2) Build the form portion, hidden at first
         self.form_header = Static(FORM_HEADER, classes="header")
         self.name_input = Input(placeholder=PLACEHOLDER_NAME,
-                                tooltip="Your name will be displayed publicly on your python.pe profile. " \
+                                tooltip="Your name will be displayed publicly on your python.pe profile. " 
                                 "Please use the name you wish to be known by in the community.")
         self.email_input = Input(placeholder=PLACEHOLDER_EMAIL,
-                                 tooltip="Your email is used for your Gravatar profile image and will not be published. " 
-                                 "It is stored securely and only used for necessary communications.")
+                                 tooltip= "Your email may appear in the repository or site outputs. "
+                                "Only provide an address you are comfortable sharing publicly.")
         self.city_input = Input(placeholder=PLACEHOLDER_CITY,
-                                 tooltip="Your city/country helps community members find others nearby. " \
+                                 tooltip="Your city/country helps community members find others nearby. " 
                                  "This will be publicly visible on your profile.")
         self.homepage_input = Input(placeholder=PLACEHOLDER_HOMEPAGE,
-                                    tooltip="Your personal website, blog, or portfolio link. " \
-                                    "This will be publicly displayed on your profile.")
+                                    tooltip="Your availability will be publicly visible to help community members know when they can reach out.")
 
         self.who_area = TextArea(tooltip="This introduction will be publicly visible on your python.pe profile.")
         self.python_area = TextArea(tooltip="Your Python experience and interests will be publicly visible.")

--- a/src/edit_python_pe/main.py
+++ b/src/edit_python_pe/main.py
@@ -68,15 +68,23 @@ class MemberApp(App):
 
         # 2) Build the form portion, hidden at first
         self.form_header = Static(FORM_HEADER, classes="header")
-        self.name_input = Input(placeholder=PLACEHOLDER_NAME)
-        self.email_input = Input(placeholder=PLACEHOLDER_EMAIL)
-        self.city_input = Input(placeholder=PLACEHOLDER_CITY)
-        self.homepage_input = Input(placeholder=PLACEHOLDER_HOMEPAGE)
+        self.name_input = Input(placeholder=PLACEHOLDER_NAME,
+                                tooltip="Your name will be displayed publicly on your python.pe profile. " \
+                                "Please use the name you wish to be known by in the community.")
+        self.email_input = Input(placeholder=PLACEHOLDER_EMAIL,
+                                 tooltip="Your email is used for your Gravatar profile image and will not be published. " 
+                                 "It is stored securely and only used for necessary communications.")
+        self.city_input = Input(placeholder=PLACEHOLDER_CITY,
+                                 tooltip="Your city/country helps community members find others nearby. " \
+                                 "This will be publicly visible on your profile.")
+        self.homepage_input = Input(placeholder=PLACEHOLDER_HOMEPAGE,
+                                    tooltip="Your personal website, blog, or portfolio link. " \
+                                    "This will be publicly displayed on your profile.")
 
-        self.who_area = TextArea()
-        self.python_area = TextArea()
-        self.contributions_area = TextArea()
-        self.availability_area = TextArea()
+        self.who_area = TextArea(tooltip="This introduction will be publicly visible on your python.pe profile.")
+        self.python_area = TextArea(tooltip="Your Python experience and interests will be publicly visible.")
+        self.contributions_area = TextArea(tooltip="Your contribution history will be publicly visible to help showcase your work.")
+        self.availability_area = TextArea(tooltip="Your availability information will help community members know when they can reach out.")
 
         self.social_container = Vertical()
         self.alias_container = Vertical()


### PR DESCRIPTION
Added tooltip attribute to name_input, email_input, city_input, and homepage_input fields.

Added tooltip attribute to all TextArea fields (who_area, python_area, contributions_area, availability_area).

All tooltips provide clear explanations of how the data will be used and stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added descriptive tooltips to profile form fields to guide users on what to enter and clarify which details are public versus private.
  * Tooltips now appear for name, email, city, and homepage inputs, plus “About you,” Python involvement, contributions, and availability text areas.
  * Placeholders and form behavior remain unchanged; tooltips improve clarity without affecting workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->